### PR TITLE
Do not check for DISABLE_WP_CRON which doesn't reflect the real WP cron state

### DIFF
--- a/admin/settings.php
+++ b/admin/settings.php
@@ -446,7 +446,7 @@ function ccfwp_advance_settings_callback() {
 
 	echo '<div class="ccfwp-heading-title">' . esc_html__( 'Generate CSS on Plugin Page reload','critical-css-for-wp');
 	echo '<div class="ccfwp-tooltip-box"><span class="dashicons dashicons-info"></span>
-    <span class="ccfwp-tooltip-text">' . esc_html__( 'This option will only work when WP cron is disabled. Critical CSS will be generated plugin page is visited. There will be a gap of 1 minutes between two consecutive requests' ,'critical-css-for-wp') . '</span>
+    <span class="ccfwp-tooltip-text">' . esc_html__( 'This option disables the WP cron event. Critical CSS will be generated on plugin page visit. There will be a gap of 1 minutes between two consecutive requests' ,'critical-css-for-wp') . '</span>
   </div></div>';
 	
 	echo '<select class="ccfwp-advance-width"  name="ccfwp_settings[ccfwp_generate_css]">';

--- a/includes/class-critical-css-for-wp.php
+++ b/includes/class-critical-css-for-wp.php
@@ -145,20 +145,17 @@ class Critical_Css_For_Wp {
 	private function ccfwp_is_wpcron_active() {
 
 		$settings           = ccfwp_defaults();
-		
-		$ccfwp_generate_css = isset( $settings['ccfwp_generation_type'] ) ? $settings['ccfwp_generation_type'] : 'auto';
-		if ( $ccfwp_generate_css == 'manual' ) {
+
+		$ccfwp_generation_type = isset( $settings['ccfwp_generation_type'] ) ? $settings['ccfwp_generation_type'] : 'auto';
+		$ccfwp_generate_css = isset( $settings['ccfwp_generate_css'] ) ? $settings['ccfwp_generate_css'] : 'off';
+		if ( $ccfwp_generation_type == 'manual' ) {
+			return false;
+		}
+		if ( $ccfwp_generate_css == 'on' ) {
 			return false;
 		}
 
-		if ( ! defined( 'DISABLE_WP_CRON' ) ) {
-			return true;
-		}
-		if ( defined( 'DISABLE_WP_CRON' ) && DISABLE_WP_CRON == false ) {
-			return true;
-		}
-		
-		return false;
+		return true;
 	}
 	public function on_term_create( $term_id, $tt_id, $taxonomy ) {
 


### PR DESCRIPTION
It is common practice to set `DISABLE_WP_CRON` to `true` and use `WP-CLI` or a `crontab` entry calling `wget` or `curl` to open the wp-cron.php file directly. Some also use online scheduling services. This ensures reliable scheduling on low-activity sites and on very busy sites it can prevent executing several cronjobs in parallel.
It is safe to assume that WP cron will always work, otherwise other plugins will also not work correctly. If the intent is to catch systems with broken cron scheduling, perhaps a better alternative would be to check the currently planned events and show a warning if there are long overdue tasks.